### PR TITLE
Add S3 attachment presign endpoint

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,6 +8,15 @@ services:
       WS_SECRET: "b88ec3b517eadde1498dede747683874cf34bf9495db89706ebb4e35ca8fc7f1"
       # set to "1" only in dev; enables /api/token helper endpoint
       ENABLE_DEV_TOKEN: "1"
+      S3_ENDPOINT: "play.min.io"
+      S3_BUCKET: "bcord-attachments"
+      S3_REGION: "us-east-1"
+      S3_ACCESS_KEY: "changeme-access"
+      S3_SECRET_KEY: "changeme-secret"
+      S3_USE_SSL: "1"
+      S3_VIRTUAL_HOSTED: "1"
+      S3_PRESIGN_TTL_SECONDS: "600"
+      S3_PUBLIC_BASE_URL: ""
       DRAIN_CLOSE_AFTER_SECONDS: "20"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:9000/api/ready || exit 1"]


### PR DESCRIPTION
## Summary
- add development S3/MinIO configuration variables to docker-compose overrides
- implement AWS SigV4 helpers and object key generation for attachments
- expose a dev-only /api/attachments/presign endpoint that returns PUT URLs plus optional GET/public URLs

## Testing
- `cmake -S bcord-infra/app -B bcord-infra/app/build` *(fails: missing Boost headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc46d71d788330badda56cdf419dbd