### PR TITLE
Serve static site from Caddy file server

### DIFF
--- a/config.json
+++ b/config.json
@@ -54,9 +54,9 @@
               ],
               "handle": [
                 {
-                  "handler": "static_response",
-                  "status_code": 200,
-                  "body": "BCord backend is up and serving API traffic only."
+                  "handler": "file_server",
+                  "root": "/srv/bcord/site",
+                  "index_names": ["index.html"]
                 }
               ]
             }


### PR DESCRIPTION
## Summary
- replace the HTTPS static response with a file server handler to serve the site content from /srv/bcord/site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b10e7450833080b889fef01f22b8