### PR TITLE
Serve React build with Caddy file server

### DIFF
--- a/caddy/config.json
+++ b/caddy/config.json
@@ -68,8 +68,16 @@
               ]
             },
             {
-              "match": [{ "host": ["b-cord.run.place", "localhost", "127.0.0.1"] }],
-              "handle": [{ "handler": "file_server", "root": "/site" }]
+              "match": [
+                { "host": ["b-cord.run.place", "localhost", "127.0.0.1"] }
+              ],
+              "handle": [
+                {
+                  "handler": "file_server",
+                  "root": "/srv/bcord/site",
+                  "index_names": ["index.html"]
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
## Summary
- update the HTTPS catch-all route so Caddy serves the React build from /srv/bcord/site with index.html fallback

## Testing
- not run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1b38a4fdc8330860a69c41496c026