### PR TITLE
Add persistent config mounts to Caddy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
       - "443:443/tcp"
       - "443:443/udp"   # HTTP/3 (QUIC)
     networks: [ net ]
+    volumes:
+      - /srv/bcord/config.json:/etc/caddy/config.json:ro
+      - /srv/bcord/site:/srv/bcord/site:ro
 
   # ---- Postgres --------------------------------------------------------------
   postgres:


### PR DESCRIPTION
## Summary
- mount the host config.json into the Caddy container
- mount the static site directory into the Caddy container

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1bcfe5cc48330a7b8e735c0516c47